### PR TITLE
Fix error message display when 'wasi-vfs' is missing

### DIFF
--- a/lib/wasmify/rails/packer.rb
+++ b/lib/wasmify/rails/packer.rb
@@ -20,7 +20,7 @@ module Wasmify
 
       def run(ruby_wasm_path:, name:, directories: Wasmify::Rails.config.pack_directories, storage_dir: nil)
         unless system("which wasi-vfs > /dev/null 2>&1")
-          raise "wasi-vfs is required to pack the application.\n"
+          raise "wasi-vfs is required to pack the application.\n" +
                "Please see installations instructions at: https://github.com/kateinoigakukun/wasi-vfs"
         end
 


### PR DESCRIPTION
```
$ cat error.rb
raise "wasi-vfs is required to pack the application.\n"
     "Please see installations instructions at: https://github.com/kateinoigakukun/wasi-vfs"
$ ruby error.rb
error.rb:1:in '<main>': wasi-vfs is required to pack the application. (RuntimeError)
```