### PR TITLE
Add safe navigation in case header is nil

### DIFF
--- a/lib/rack/data_uri_uploads.rb
+++ b/lib/rack/data_uri_uploads.rb
@@ -21,7 +21,7 @@ module Rack
 
       if (
         request.post? || request.put? || request.patch?
-      ) && request.get_header("HTTP_CONTENT_TYPE").match?(%r{multipart/form-data})
+      ) && request.get_header("HTTP_CONTENT_TYPE")&.match?(%r{multipart/form-data})
         transform_params(request.params)
         env["action_dispatch.request.request_parameters"] = request.params
       end


### PR DESCRIPTION
Thanks for wasmify-rails, the project is phenomenally cool 😎 

When running in the development environment (i.e. not wasm), POST requests result in an error if the `HTTP_CONTENT_TYPE` header can't be found in the request. This PR addresses the issue by adding a safe navigation operator.