### PR TITLE
Fix source URL override: build_source_aliases → build_config_aliases

### DIFF
--- a/lib/wasmify/rails/builder.rb
+++ b/lib/wasmify/rails/builder.rb
@@ -8,7 +8,10 @@ require "ruby_wasm/cli"
 # Patch ruby.wasm CLI to use the latest patch versions of Ruby
 RubyWasm::CLI.singleton_class.prepend(Module.new do
   def build_source_aliases(root)  # for ruby_wasm 2.8.x and earlier
-    super
+    super.tap do |sources|
+      sources["3.3"][:url] = "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.8.tar.gz"
+      sources["3.4"][:url] = "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.3.tar.gz"
+    end
   end
 
   def build_config_aliases(root)  # for ruby_wasm 2.9.0+

--- a/lib/wasmify/rails/builder.rb
+++ b/lib/wasmify/rails/builder.rb
@@ -7,10 +7,15 @@ require "ruby_wasm/cli"
 
 # Patch ruby.wasm CLI to use the latest patch versions of Ruby
 RubyWasm::CLI.singleton_class.prepend(Module.new do
-  def build_source_aliases(root)
+  def build_source_aliases(root)  # for ruby_wasm 2.8.x and earlier
+    super
+  end
+
+  def build_config_aliases(root)  # for ruby_wasm 2.9.0+
     super.tap do |sources|
-      sources["3.3"][:url] = "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.8.tar.gz"
-      sources["3.4"][:url] = "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.3.tar.gz"
+      sources["3.3"][:src][:url] = "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.11.tar.gz"
+      sources["3.4"][:src][:url] = "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.8.tar.gz"
+      sources["4.0"][:src][:url] = "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.2.tar.gz"
     end
   end
 end)


### PR DESCRIPTION
## Summary

`ruby_wasm` 2.9.0 renamed `RubyWasm::CLI#build_source_aliases` to `#build_config_aliases`. The current `wasmify-rails` code patches the old method name, so the source URL override is silently ignored on ruby_wasm 2.9.0+.

## Problem

In `lib/wasmify/rails/builder.rb`, the monkey-patch targets
`build_source_aliases`:
```ruby
RubyWasm::CLI.singleton_class.prepend(Module.new do
  def build_source_aliases(root)
    super.tap do |sources|
      sources["3.3"][:url] = "..."
      sources["3.4"][:url] = "..."
    end
  end
end)
```

Since ruby_wasm 2.9.0, this method has been renamed to `build_config_aliases` and the hash structure changed from `sources["3.x"][:url]` to `sources["3.x"][:src][:url]`. The prepend succeeds without error, but the overridden method is never called, so custom Ruby source URLs are not applied.

## Fix

Add `build_config_aliases` for ruby_wasm 2.9.0+ while keeping `build_source_aliases` for backward compatibility with ruby_wasm 2.8.x. URL versions in `build_source_aliases` are left as-is; open to author's discretion.

## Context

Discovered while building Ruby 3.4 and 4.0 for WASM in the rubree project.
Workaround (local rake task overriding the correct method): https://github.com/aim2bpg/rubree/blob/main/lib/tasks/wasmify_patches.rake

## Related

- #7 — Ruby 3.4 WASM compatibility