### PR TITLE
Add require rubygems to shim.rb for Ruby 4.0 compatibility

### DIFF
--- a/lib/wasmify/rails/shim.rb
+++ b/lib/wasmify/rails/shim.rb
@@ -13,6 +13,7 @@ end
 return unless on_wasm?
 
 # Setup Bundler
+require "rubygems"
 require "/bundle/setup"
 require "bundler"
 


### PR DESCRIPTION
## Summary

On Ruby 4.0 WASM builds, `shim.rb` fails with `uninitialized constant Gem::Deprecate (NameError)` because RubyGems is not
fully loaded when `require "/bundle/setup"` runs. Adding `require "rubygems"` before the bundle setup resolves the issue.

## Problem

Ruby 4.0 pre-defines `Gem` at the C level but does not fully load RubyGems.
When `shim.rb` calls `require "/bundle/setup"`, Bundler internally references `Gem::Deprecate`, causing a `NameError` at boot.

## Fix

Add one line to `lib/wasmify/rails/shim.rb`:
```ruby
require "rubygems"    # Ensure RubyGems is fully loaded (needed for Ruby 4.0+)
require "/bundle/setup"
```

This is a no-op on Ruby 3.3 and 3.4 where RubyGems is already fully loaded at this point.

## Context

Discovered while adding Ruby 4.0 WASM support to the rubree project.
Workaround (auto-patching shim.rb at build time):
https://github.com/aim2bpg/rubree/blob/main/lib/tasks/wasmify_patches.rake

## Related

- #7 — Ruby 3.4 WASM compatibility